### PR TITLE
chore: prevent flickering if user is already logged in

### DIFF
--- a/apps/native/app/(root)/_layout.tsx
+++ b/apps/native/app/(root)/_layout.tsx
@@ -1,5 +1,6 @@
 import { useConvexAuth } from "convex/react";
 import { Stack } from "expo-router";
+import { Spinner } from "heroui-native";
 import { useNavigationOptions } from "@/hooks/useNavigationOptions";
 
 export const unstable_settings = {
@@ -11,23 +12,31 @@ export default function RootLayout() {
   const { root } = useNavigationOptions();
   /* --------------------------------- return --------------------------------- */
   return (
-    <Stack>
-      {/* AUTH STACK */}
-      <Stack.Protected guard={!isAuthenticated}>
-        <Stack.Screen name="(auth)" options={{ headerShown: false }} />
-      </Stack.Protected>
-      {/* AUTHENTICATED NESTED STACK */}
-      <Stack.Protected guard={isAuthenticated}>
-        {/* MAIN STACK*/}
-        <Stack.Screen
-          name="(main)"
-          options={{
-            title: "",
-            headerShown: false,
-            ...root,
-          }}
-        />
-      </Stack.Protected>
-    </Stack>
+    <>
+      {isLoading ? (
+        <View className="flex-1 items-center justify-center">
+          <Spinner size="lg" />
+        </View>
+      ) : (
+        <Stack>
+          {/* AUTH STACK */}
+          <Stack.Protected guard={!isAuthenticated}>
+            <Stack.Screen name="(auth)" options={{ headerShown: false }} />
+          </Stack.Protected>
+          {/* AUTHENTICATED NESTED STACK */}
+          <Stack.Protected guard={isAuthenticated}>
+            {/* MAIN STACK*/}
+            <Stack.Screen
+              name="(main)"
+              options={{
+                title: "",
+                headerShown: false,
+                ...root,
+              }}
+            />
+          </Stack.Protected>
+        </Stack>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
Problem: if a user is already logged in he will be presented the auth index screen after a reaload or on opening the app:

![Simulator Screen Recording - iPhone 16 Pro - 2025-09-09 at 20 15 48](https://github.com/user-attachments/assets/96f65667-c545-46b8-bae8-081e28cfb56e)

Here a spinner is shown if the convex auth state is still loading:
![Simulator Screen Recording - iPhone 16 Pro - 2025-09-09 at 20 16 15](https://github.com/user-attachments/assets/5bb7a00e-8b1c-4400-a46e-fbf1230cb89e)

The code is more as an example than a concrete solution. But you get the idea I guess.